### PR TITLE
Support Vagrant for local testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,20 @@ language: python
 python: "2.7"
 
 env:
-  - SITE=test.yml
+  - PLAYBOOK=test.yml
 
 before_install:
   - sudo apt-get update -qq
 
   # Remove MySQL. Completely and totally.
+  - sudo service mysql stop
   - sudo apt-get remove --purge 'mysql*'
   - sudo apt-get autoremove
   - sudo apt-get autoclean
+  - sudo deluser mysql
   - sudo rm -rf /var/lib/mysql
-  - sudo truncate -s 0 /var/log/mysql/error.log
+  - sudo apt-get purge mysql-server-core*
+  - sudo apt-get purge mysql-client-core*
 
 install:
   # Install Ansible.
@@ -24,14 +27,14 @@ install:
 
 script:
   # Check the role/playbook's syntax.
-  - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
+  - "ansible-playbook -i inventory/travis.ini $PLAYBOOK --syntax-check"
 
   # Run the role/playbook with ansible-playbook.
-  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
+  - "ansible-playbook -i inventory/travis.ini $PLAYBOOK --connection=local --sudo"
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
-    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
+    ansible-playbook -i inventory/travis.ini $PLAYBOOK --connection=local --sudo
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# vi: set ft=ruby et ts=2 sw=2:
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "base"
+
+  config.vm.define "debian6", primary: true, autostart: true do |debian|
+      debian.vm.box = "chef/debian-6.0.8"
+      debian.vm.network "private_network", ip: "192.168.42.31"
+      debian.vm.hostname = "debian6.mysql.local"
+
+      debian.vm.provider :virtualbox do |vbox|
+          vbox.name = "debian6.ansible-mysql-role"
+      end
+
+      debian.vm.provision "ansible" do |ansible|
+          ansible.playbook = "test.yml"
+          ansible.inventory_path = "inventory/vagrant.ini"
+          ansible.limit = "all"
+      end
+  end
+end

--- a/inventory/travis.ini
+++ b/inventory/travis.ini
@@ -1,0 +1,5 @@
+# inventory/travis.ini
+#
+# Travis inventory for Ansible.
+
+localhost ansible_ssh_user=root

--- a/inventory/vagrant.ini
+++ b/inventory/vagrant.ini
@@ -1,0 +1,5 @@
+# inventory/vagrant.ini
+#
+# Vagrant inventory file
+
+debian6.mysql.local ansible_ssh_host=192.168.42.31 ansible_ssh_user=vagrant ansible_ssh_private_key=~/.vagrant.d/insecure_private_key

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,17 @@
+# test.yml
+#
+# Playbook to test the role under different environments,
+# like Vagrant and Travis.
+---
+- hosts: all
+  sudo: yes
+  vars_files:
+    - "defaults/main.yml"
+  tasks:
+    - include: "tasks/main.yml"
+      vars:
+        mysql_innodb_log_file_size: "5M"
+  handlers:
+    - include: "handlers/main.yml"
+
+# ex: ft=ansible et ts=2 sw=2:

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,8 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  vars:
-    # Use default log file size so Travis CI VM allows MySQL restart.
-    - mysql_innodb_log_file_size: "5M"
-  roles:
-    - ansible-role-mysql


### PR DESCRIPTION
Adds a Vagrantfile supporting just one VM (Debian 6), provisioning the
`test.yml` playbook, which prompted the creation of `inventory` directory
to hold Travis and Vagrant inventories (Which could, as well, be in the
same file).

Moves contents off `tests` directory:
    - `tests/test.yml` -> `test.yml`;
    - `tests/inventory` -> `inventory/travis.ini`;

Changes `test.yml` from running the role installed to including the
tasks, variable files and handlers provided by the role, `.travis.yml`
was changed to reflect all these changes.
